### PR TITLE
Fix double-multiply of scale

### DIFF
--- a/render.go
+++ b/render.go
@@ -42,7 +42,7 @@ func (r *Renderer) DrawString(str string, img draw.Image, face fonts.Face) int {
 		RunStart: 0,
 		RunEnd:   len(str),
 		Face:     face,
-		Size:     fixed.I(int(r.FontSize * r.PixScale)),
+		Size:     fixed.I(int(r.FontSize)),
 	}
 	out := r.cachedShaper().Shape(in)
 	return r.DrawShapedRunAt(out, img, 0, out.LineBounds.Ascent.Ceil())
@@ -62,7 +62,7 @@ func (r *Renderer) DrawStringAt(str string, img draw.Image, x, y int, face fonts
 		RunStart: 0,
 		RunEnd:   len(str),
 		Face:     face,
-		Size:     fixed.I(int(r.FontSize * r.PixScale)),
+		Size:     fixed.I(int(r.FontSize)),
 	}
 	return r.DrawShapedRunAt(r.cachedShaper().Shape(in), img, x, y)
 }
@@ -72,10 +72,10 @@ func (r *Renderer) DrawStringAt(str string, img draw.Image, x, y int, face fonts
 // Note that startX and startY are not multiplied by the `PixScale` value as they refer to output coordinates.
 // The return value is the X pixel position of the end of the drawn string.
 func (r *Renderer) DrawShapedRunAt(run shaping.Output, img draw.Image, startX, startY int) int {
-	scale := r.FontSize * r.PixScale / float32(run.Face.Upem())
 	if r.PixScale == 0 {
 		r.PixScale = 1
 	}
+	scale := r.FontSize * r.PixScale / float32(run.Face.Upem())
 
 	b := img.Bounds()
 	scanner := rasterx.NewScannerGV(b.Dx(), b.Dy(), img, b)

--- a/render_test.go
+++ b/render_test.go
@@ -42,3 +42,29 @@ func Test_Render(t *testing.T) {
 	png.Encode(w, img)
 	w.Close()
 }
+
+func TestRender_PixScaleAdvance(t *testing.T) {
+	img := image.NewNRGBA(image.Rect(0, 0, 350, 180))
+
+	data, _ := os.Open("testdata/NotoSans-Regular.ttf")
+	f, _ := font.ParseTTF(data)
+
+	r := &render.Renderer{
+		FontSize: 48,
+		Color:    color.Black,
+	}
+	str := "Testing"
+	adv0 := r.DrawString(str, img, f)
+
+	r.PixScale = 1 // instead of the zero value
+	adv1 := r.DrawString(str, img, f)
+	if adv0 != adv1 {
+		t.Error("unscaled font did not advance as default")
+	}
+
+	r.PixScale = 2
+	adv2 := r.DrawString(str, img, f)
+	if adv2 <= int(float32(adv1)*1.9) || adv2 >= int(float32(adv1)*2.1) {
+		t.Error("scaled font did not advance proportionately")
+	}
+}


### PR DESCRIPTION
The output image from the tests is the same as I showed before - somehow an error crept in at the end of the prior PR that went undetected...

![out](https://user-images.githubusercontent.com/294436/219012317-72c2bc17-b9e9-4340-b698-2e6f5d60ee71.png)
