### PR TITLE
Cache the shaper inline in the struct instead

### DIFF
--- a/render.go
+++ b/render.go
@@ -27,7 +27,7 @@ type Renderer struct {
 	Color color.Color
 
 	segmenter   shaping.Segmenter
-	shaper      shaping.Shaper
+	shaper      shaping.HarfbuzzShaper
 	filler      *rasterx.Filler
 	fillerScale float32
 }
@@ -45,9 +45,8 @@ func (r *Renderer) shape(str string, face font.Face) (_ shaping.Line, ascent int
 	runs := r.segmenter.Split(in, singleFontMap{face})
 
 	line := make(shaping.Line, len(runs))
-	shaper := r.cachedShaper()
 	for i, run := range runs {
-		line[i] = shaper.Shape(run)
+		line[i] = r.shaper.Shape(run)
 		if a := line[i].LineBounds.Ascent.Ceil(); a > ascent {
 			ascent = a
 		}
@@ -116,14 +115,6 @@ func (r *Renderer) DrawShapedRunAt(run shaping.Output, img draw.Image, startX, s
 	f.Draw()
 	r.filler = nil
 	return int(math.Ceil(float64(x)))
-}
-
-func (r *Renderer) cachedShaper() shaping.Shaper {
-	if r.shaper == nil {
-		r.shaper = &shaping.HarfbuzzShaper{}
-	}
-
-	return r.shaper
 }
 
 func (r *Renderer) drawOutline(g shaping.Glyph, bitmap api.GlyphOutline, f *rasterx.Filler, scale float32, x, y float32) {


### PR DESCRIPTION
Just a small change that makes the code a bit more readable and improves performance ever so slightly. There is no need to allocate the shaper externally and store it in an interface field, we can just embed the type without a pointer and avoid the nil-check entirely. All the fields of the type are now baked in to the `Renderer` struct instead. 