### PR TITLE
Update so that bitmap font output is top aligned not baseline aligned

### DIFF
--- a/render.go
+++ b/render.go
@@ -105,7 +105,12 @@ func (r *Renderer) DrawShapedRunAt(run shaping.Output, img draw.Image, startX, s
 		case api.GlyphOutline:
 			r.drawOutline(g, format, f, scale, xPos, yPos)
 		case api.GlyphBitmap:
-			_ = r.drawBitmap(g, format, img, xPos, yPos)
+			// align bitmaps to the top edge not baseline
+			e, _ := run.Face.FontVExtents()
+			asc := e.Ascender/float32(run.Face.Upem())
+			yPxOff := asc*fixed266ToFloat(-g.Height)*r.PixScale
+
+			_ = r.drawBitmap(g, format, img, xPos, yPos-yPxOff)
 		case api.GlyphSVG:
 			_ = r.drawSVG(g, format, img, xPos, yPos)
 		}


### PR DESCRIPTION
Fixes #15

I am not certain why bitmap font output appears 25% larger than the SVG equivalent - I think that may be a separate issue...

![out](https://github.com/go-text/render/assets/294436/1a70afd7-2914-401e-854a-a6e4306fef50)
